### PR TITLE
Use a headless jre to get a smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sou
 		make \
 		shellcheck \
         less \
-        default-jre \
+        default-jre-headless \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/* \
     && useradd -m builder


### PR DESCRIPTION
We don't need graphical libraries